### PR TITLE
Asynchronous

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,47 @@
+$(document).on('turbolinks:load', function(){
+  function buildHTML(message){
+    var img = message.image ? `<img src= ${ message.image } class="message-image">` : "";
+    
+    var html = `<div class="message">
+                  <div class="message__upper-info">
+                    <div class="message__upper-info--talker">
+                      ${message.user_name}
+                    </div>
+                    <div class="message__upper-info--date">
+                      ${message.created_at}
+                    </div>
+                  </div>
+                  <div class="message__text">
+                    ${message.content}
+                  </div>
+                    ${img}
+                </div>`
+    return html;
+  }
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.message-box').append(html)
+      $('#new_message')[0].reset();
+      $('.main-body').animate({ scrollTop: $('.main-body')[0].scrollHeight });
+      $('.send-btn').prop("disabled", false);
+    })
+    .fail(function(data){
+      alert('入力されていません');
+      $('.send-btn').prop("disabled", false);
+    })
+  })
+})
+

--- a/app/assets/stylesheets/_message.scss
+++ b/app/assets/stylesheets/_message.scss
@@ -20,3 +20,6 @@
     margin-bottom: 10px;
   }
 }
+.message-image {
+  width: 200px;
+}

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,17 +8,14 @@ class MessagesController < ApplicationController
 
   def create
     @message = @group.messages.new(message_params)
-    if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
-    else
-      @messages = @group.messages.includes(:user)
-      flash.now[:alert] = 'メッセージを入力してください。'
-      render :index
+    @message.save
+    respond_to do |format|
+      format.html { redirect_to group_messages_path(params[:group_id]) }
+      format.json
     end
   end
 
   private
-
   def message_params
     params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
   end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -7,4 +7,4 @@
   .message__text
     - if message.content.present?
       = message.content
-    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+  = image_tag message.image.url, class: 'message-image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.content    @message.content
+json.image      @message.image.url
+json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.user_name  @message.user.name
+json.id         @message.id

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# what
jsファイルとjson.jbuilderファイルを記述し、イベントが発火したときにAjaxを使用して、messages#createを動かす。
HTMLをメッセージ画面の一番下に追加し、メッセージ画面を下にスクロールする。
連続で送信ボタンを押せるようにする。
# why
非同期にすることで、ビューは再描画せず、必要なデータを返す処理のみが可能になる。

https://gyazo.com/00c7edce9e75b10eea145cebb1b1bfb1