### PR TITLE
automatic updating implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'pry-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       image_processing (~> 1.1)
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -126,6 +127,11 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
@@ -248,6 +254,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   rails-controller-testing

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,8 @@
 $(document).on('turbolinks:load', function(){
   function buildHTML(message){
-    var img = message.image ? `<img src= ${ message.image } class="message-image">` : "";
+    var img = message.image.url ? `<img src= ${ message.image.url } class="message-image">` : "";
     
-    var html = `<div class="message">
+    var html = `<div class="message" data-id="${message.id}">
                   <div class="message__upper-info">
                     <div class="message__upper-info--talker">
                       ${message.user_name}
@@ -35,7 +35,7 @@ $(document).on('turbolinks:load', function(){
       var html = buildHTML(data);
       $('.message-box').append(html)
       $('#new_message')[0].reset();
-      $('.main-body').animate({ scrollTop: $('.main-body')[0].scrollHeight });
+      $('.main-body').animate({ scrollTop: $('.main-body')[0].scrollHeight }, 'fast');
       $('.send-btn').prop("disabled", false);
     })
     .fail(function(data){
@@ -43,5 +43,29 @@ $(document).on('turbolinks:load', function(){
       $('.send-btn').prop("disabled", false);
     })
   })
+
+  var reloadMessages = function() {
+    if (location.href.match(/\/groups\/\d+\/messages/)){
+      var last_message_id = $('.message:last').data('id');
+      $.ajax({
+        url: "api/messages",
+        type: 'get',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        var insertHTML = '';
+        messages.forEach(function (message) {
+        insertHTML = buildHTML(message);
+        $('.message-box').append(insertHTML)
+        $('.main-body').animate({ scrollTop: $('.main-body')[0].scrollHeight }, 'fast');
+        })
+      })
+      .fail(function() {
+        alert('error');
+      });
+    }
+  };
+  setInterval(reloadMessages, 5000);
 })
 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {id: "#{message.id}"}}
   .message__upper-info
     .message__upper-info--talker
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.content    @message.content
-json.image      @message.image.url
+json.image      @message.image
 json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.user_name  @message.user.name
 json.id         @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# what
ユーザーがグループのメッセージ画面を開いてる時に、
リロードを行わなくても自動でメッセージが更新されるよう実装しました。
# why
チャットなので、自動で更新されると投稿と同時にに他ユーザーのメッセージが閲覧可能になるからです。自動更新がない場合、毎回リロードすることになるのでUIにはかけるからです。
# 動画キャプチャ
https://gyazo.com/38d1340ef25a37df8b10531c911fb1b2